### PR TITLE
gitattributes for proper GLSL code handling by Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Trivial file extensions
+*.frag linguist-language=GLSL
+*.vert linguist-language=GLSL
+*.geom linguist-language=GLSL
+
+# This project's file extensions
+*.glslv linguist-language=GLSL
+*.glslf linguist-language=GLSL
+
+## Experimental
+*.glsl* linguist-language=GLSL


### PR DESCRIPTION
Github is behind times yet again, just like with the Solidity language. The new .gitattributes file forces Github to index and count the GLSL code correctly